### PR TITLE
Optimize Docker image build steps and add latest tag push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -49,11 +49,15 @@ jobs:
         TAG=$(date +'%Y%m%d-%H%M%S')-$(git rev-parse --short HEAD)
         echo "tag=$TAG" >> $GITHUB_OUTPUT
 
-    - name: Build Docker image
-      run: docker build -t ezsky333/anilinkserver:${{ steps.vars.outputs.tag }} .
+    - name: Build Docker image with tags
+      run: |
+        docker build -t ezsky333/anilinkserver:${{ steps.vars.outputs.tag }} -t ezsky333/anilinkserver:latest .
 
-    - name: Push Docker image to Docker Hub
+    - name: Push Docker image with tag
       run: docker push ezsky333/anilinkserver:${{ steps.vars.outputs.tag }}
+
+    - name: Push Docker image with latest tag
+      run: docker push ezsky333/anilinkserver:latest
 
     - name: Logout of Docker Hub
       run: docker logout


### PR DESCRIPTION
Enhance the Docker image build process by adding a step to push the latest tag alongside the versioned tag. This improves the deployment workflow.