### PR TITLE
添加视频元数据获取视频管理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ build/
 .vscode/
 data/**
 api/data/**
+media/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
 FROM openjdk:17-ea
-#创建响应文件夹
+
+# 更新包管理器并安装 FFmpeg 和相关工具
+RUN apt-get update && apt-get install -y \
+    ffmpeg \
+    curl \
+    ca-certificates && \
+    rm -rf /var/lib/apt/lists/*
+
+# 创建响应文件夹
 RUN mkdir -p /app/config
+
 # 设置环境变量，用于用户指定媒体目录和配置目录
 ENV CONFIG_DIR /app/config
 ADD api/target/ani-link-service.jar app.jar
@@ -8,6 +17,7 @@ ENV LANG=C.UTF-8
 ENV LANGUAGE C.UTF-8
 ENV LC_ALL=C.UTF-8
 EXPOSE 8081
-#运行程序主体
+
+# 运行程序主体
 ENTRYPOINT ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.jar"]
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -82,6 +82,11 @@
 			<artifactId>hutool-all</artifactId>
 			<version>5.8.26</version>
 		</dependency>
+		<!-- Jackson for JSON parsing (FFprobe output) -->
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<finalName>${project.artifactId}</finalName>

--- a/api/src/main/java/xyz/ezsky/anilink/controller/MediaFileController.java
+++ b/api/src/main/java/xyz/ezsky/anilink/controller/MediaFileController.java
@@ -1,0 +1,114 @@
+package xyz.ezsky.anilink.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
+
+import cn.dev33.satoken.annotation.SaCheckRole;
+import xyz.ezsky.anilink.model.dto.MediaFileDTO;
+import xyz.ezsky.anilink.model.dto.UpdateMediaFileRequest;
+import xyz.ezsky.anilink.model.vo.ApiResponseVO;
+import xyz.ezsky.anilink.model.vo.PageVO;
+import xyz.ezsky.anilink.model.vo.QueueStatusVO;
+import xyz.ezsky.anilink.service.MediaFileService;
+import xyz.ezsky.anilink.service.MediaMetadataQueueManager;
+
+/**
+ * 媒体文件管理API
+ */
+@Tag(name = "媒体文件管理", description = "用于查询、更新和删除媒体文件记录")
+@RestController
+@RequestMapping("/api/media-files")
+public class MediaFileController {
+
+    @Autowired
+    private MediaFileService mediaFileService;
+
+    @Autowired
+    private MediaMetadataQueueManager metadataQueueManager;
+
+    @Operation(summary = "分页查询媒体文件列表", description = "查询媒体文件列表，支持按媒体库过滤")
+    @SaCheckRole("super-admin")
+    @GetMapping
+    public ApiResponseVO<PageVO<MediaFileDTO>> getMediaFiles(
+            @Parameter(description = "媒体库ID，不提供则查询所有", required = false)
+            @RequestParam(required = false) Long libraryId,
+            @Parameter(description = "页码，从0开始", required = false)
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "每页大小", required = false)
+            @RequestParam(defaultValue = "20") int pageSize) {
+        return ApiResponseVO.success(mediaFileService.getMediaFiles(libraryId, page, pageSize));
+    }
+
+    @Operation(summary = "获取媒体文件详情", description = "根据ID获取单个媒体文件的完整信息，包括所有技术元数据")
+    @SaCheckRole("super-admin")
+    @GetMapping("/{id}")
+    public ApiResponseVO<MediaFileDTO> getMediaFileDetail(
+            @Parameter(description = "媒体文件ID")
+            @PathVariable Long id) {
+        MediaFileDTO dto = mediaFileService.getMediaFileDetail(id);
+        if (dto == null) {
+            return ApiResponseVO.fail("媒体文件不存在");
+        }
+        return ApiResponseVO.success(dto);
+    }
+
+    @Operation(summary = "批量重新获取元数据", description = "对指定媒体库中的所有文件重新触发元数据提取（异步处理）")
+    @SaCheckRole("super-admin")
+    @PostMapping("/reprocess-metadata/{libraryId}")
+    public ApiResponseVO<Void> reprocessMetadata(
+            @Parameter(description = "媒体库ID")
+            @PathVariable Long libraryId) {
+        try {
+            mediaFileService.reprocessMetadataForLibrary(libraryId);
+            return ApiResponseVO.success(null, "已提交元数据重新获取任务，请稍候");
+        } catch (Exception e) {
+            return ApiResponseVO.fail("提交任务失败: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "删除媒体文件", description = "删除指定的媒体文件记录，可选是否同时删除硬盘上的文件")
+    @SaCheckRole("super-admin")
+    @DeleteMapping("/{id}")
+    public ApiResponseVO<Void> deleteMediaFile(
+            @Parameter(description = "媒体文件ID")
+            @PathVariable Long id,
+            @Parameter(description = "是否同时删除硬盘上的文件", required = false)
+            @RequestParam(defaultValue = "false") boolean deleteFile) {
+        try {
+            mediaFileService.deleteMediaFile(id, deleteFile);
+            return ApiResponseVO.success(null, "删除成功");
+        } catch (Exception e) {
+            return ApiResponseVO.fail("删除失败: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "更新文件信息", description = "更新媒体文件的动漫相关信息（episodeId、animeId、标题等）")
+    @SaCheckRole("super-admin")
+    @PutMapping("/{id}")
+    public ApiResponseVO<Void> updateMediaFile(
+            @Parameter(description = "媒体文件ID")
+            @PathVariable Long id,
+            @RequestBody UpdateMediaFileRequest request) {
+        try {
+            mediaFileService.updateMediaFile(id, request);
+            return ApiResponseVO.success(null, "更新成功");
+        } catch (Exception e) {
+            return ApiResponseVO.fail("更新失败: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "查询队列状态", description = "查询当前元数据提取队列的状态，包括待处理任务数和活跃线程数")
+    @SaCheckRole("super-admin")
+    @GetMapping("/queue/status")
+    public ApiResponseVO<QueueStatusVO> getQueueStatus() {
+        QueueStatusVO status = QueueStatusVO.builder()
+                .pendingTasks(metadataQueueManager.getQueueSize())
+                .activeThreads(metadataQueueManager.getActiveThreadCount())
+                .maxPoolSize(metadataQueueManager.getMaxPoolSize())
+                .build();
+        return ApiResponseVO.success(status);
+    }
+}

--- a/api/src/main/java/xyz/ezsky/anilink/model/dto/MediaFileDTO.java
+++ b/api/src/main/java/xyz/ezsky/anilink/model/dto/MediaFileDTO.java
@@ -1,0 +1,51 @@
+package xyz.ezsky.anilink.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+/**
+ * 媒体文件数据传输对象
+ * 用于API响应和前端数据展示
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MediaFileDTO {
+    private Long id;
+    private Long libraryId;
+    private String fileName;
+    private String filePath;
+    private Long size;
+    private Long lastModified;
+    
+    // 外部接口获取的字段
+    private String episodeId;
+    private Long animeId;
+    private String animeTitle;
+    private String episodeTitle;
+    
+    // FFprobe 提取的字段
+    private Long duration;
+    private String hash;
+    private Integer width;
+    private Integer height;
+    private String aspectRatio;
+    private String colorDepth;
+    private String hdrType;
+    private String colorSpace;
+    private String colorPrimaries;
+    private Long videoBitrate;
+    private Double fps;
+    private String containerFormat;
+    private String videoCodec;
+    private String audioCodec;
+    private Boolean metadataFetched;
+    
+    private Timestamp createdAt;
+    private Timestamp updatedAt;
+}

--- a/api/src/main/java/xyz/ezsky/anilink/model/dto/MediaMetadata.java
+++ b/api/src/main/java/xyz/ezsky/anilink/model/dto/MediaMetadata.java
@@ -1,0 +1,44 @@
+package xyz.ezsky.anilink.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 媒体文件元数据 DTO
+ * 
+ * 包含从 FFprobe 提取的视频/音频信息和计算的哈希值
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MediaMetadata {
+
+    // FFprobe 提取的字段
+    private Long duration;           // 视频长度（毫秒）
+    private String hash;             // 文件前16MB的MD5哈希
+    
+    // 视频流信息
+    private Integer width;            // 分辨率：宽度
+    private Integer height;           // 分辨率：高度
+    private String aspectRatio;       // 宽高比（如 16:9）
+    private String colorDepth;        // 色彩深度（8-bit、10-bit 等）
+    private String hdrType;           // HDR 类型（HDR10、HDR10+、Dolby Vision 等）
+    private String colorSpace;        // 色彩空间（如 Rec.709、Rec.2020）
+    private String colorPrimaries;    // 色彩原色（如 PQ、HLG）
+    private Double fps;               // 帧率（如 23.976、24、25、29.97 等）
+    private Long videoBitrate;        // 视频码率（bps）
+    private String videoCodec;        // 视频编码（如 h264、hevc、av1）
+
+    // 音频流信息
+    private String audioCodec;        // 音频编码（如 aac、flac、opus）
+
+    // 容器信息
+    private String containerFormat;   // 容器格式（MKV、MP4、AVI 等）
+
+    // 标记该记录是否成功获取元数据
+    private boolean success;
+    private String errorMessage;      // 获取失败时的错误信息
+}

--- a/api/src/main/java/xyz/ezsky/anilink/model/dto/UpdateMediaFileRequest.java
+++ b/api/src/main/java/xyz/ezsky/anilink/model/dto/UpdateMediaFileRequest.java
@@ -1,0 +1,20 @@
+package xyz.ezsky.anilink.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 更新媒体文件信息的请求DTO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateMediaFileRequest {
+    private String episodeId;
+    private Long animeId;
+    private String animeTitle;
+    private String episodeTitle;
+}

--- a/api/src/main/java/xyz/ezsky/anilink/model/entity/MediaFile.java
+++ b/api/src/main/java/xyz/ezsky/anilink/model/entity/MediaFile.java
@@ -34,9 +34,68 @@ public class MediaFile {
     @Column(nullable = false)
     private Long size;
 
+    // 外部接口获取的字段（预留方法）
+    @Column(name = "episode_id", length = 255)
+    private String episodeId;
+
+    @Column(name = "anime_id")
+    private Long animeId;
+
+    @Column(name = "anime_title", length = 500)
+    private String animeTitle;
+
+    @Column(name = "episode_title", length = 500)
+    private String episodeTitle;
+
+    // FFprobe 提取的字段
+    @Column(name = "duration")
+    private Long duration;
+
+    @Column(name = "hash", length = 32)
+    private String hash;
+
+    @Column(name = "width")
+    private Integer width;
+
+    @Column(name = "height")
+    private Integer height;
+
+    @Column(name = "aspect_ratio", length = 20)
+    private String aspectRatio;
+
+    @Column(name = "color_depth", length = 50)
+    private String colorDepth;
+
+    @Column(name = "hdr_type", length = 50)
+    private String hdrType;
+
+    @Column(name = "color_space", length = 50)
+    private String colorSpace;
+
+    @Column(name = "color_primaries", length = 50)
+    private String colorPrimaries;
+
+    @Column(name = "video_bitrate")
+    private Long videoBitrate;
+
+    @Column(name = "fps")
+    private Double fps;
+
+    @Column(name = "container_format", length = 50)
+    private String containerFormat;
+
+    @Column(name = "video_codec", length = 100)
+    private String videoCodec;
+
+    @Column(name = "audio_codec", length = 100)
+    private String audioCodec;
+
+    @Column(name = "metadata_fetched", nullable = false)
+    private Boolean metadataFetched = false;
+
     @Column(name = "created_at", nullable = false, updatable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp createdAt;
 
-    @Column(name = "updated_at", nullable = false, insertable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
+    @Column(name = "updated_at", nullable = false, insertable = false, updatable = false, columnDefinition = "TIMESTAMP DEFAULT CURRENT_TIMESTAMP")
     private Timestamp updatedAt;
 }

--- a/api/src/main/java/xyz/ezsky/anilink/model/vo/PageVO.java
+++ b/api/src/main/java/xyz/ezsky/anilink/model/vo/PageVO.java
@@ -1,0 +1,25 @@
+package xyz.ezsky.anilink.model.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * 分页响应VO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PageVO<T> {
+    private List<T> content;
+    private long totalElements;
+    private int totalPages;
+    private int currentPage;
+    private int pageSize;
+    private boolean hasNext;
+    private boolean hasPrevious;
+}

--- a/api/src/main/java/xyz/ezsky/anilink/model/vo/QueueStatusVO.java
+++ b/api/src/main/java/xyz/ezsky/anilink/model/vo/QueueStatusVO.java
@@ -1,0 +1,20 @@
+package xyz.ezsky.anilink.model.vo;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * 元数据提取队列状态VO
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class QueueStatusVO {
+    private int pendingTasks;      // 队列中待处理的任务数
+    private int activeThreads;     // 正在处理的线程数
+    private int maxPoolSize;       // 线程池最大线程数
+    private long totalProcessed;   // 已处理的总任务数（可选）
+}

--- a/api/src/main/java/xyz/ezsky/anilink/service/MediaFileService.java
+++ b/api/src/main/java/xyz/ezsky/anilink/service/MediaFileService.java
@@ -1,0 +1,219 @@
+package xyz.ezsky.anilink.service;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import xyz.ezsky.anilink.model.dto.MediaFileDTO;
+import xyz.ezsky.anilink.model.dto.UpdateMediaFileRequest;
+import xyz.ezsky.anilink.model.entity.MediaFile;
+import xyz.ezsky.anilink.model.entity.MediaLibrary;
+import xyz.ezsky.anilink.model.vo.PageVO;
+import xyz.ezsky.anilink.repository.MediaFileRepository;
+import xyz.ezsky.anilink.repository.MediaLibraryRepository;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 媒体文件业务服务
+ * 
+ * 负责处理媒体文件的查询、更新、删除等操作
+ */
+@Log4j2
+@Service
+public class MediaFileService {
+
+    @Autowired
+    private MediaFileRepository mediaFileRepository;
+
+    @Autowired
+    private MediaLibraryRepository mediaLibraryRepository;
+
+    @Autowired
+    private MediaMetadataEnricher mediaMetadataEnricher;
+
+    @Autowired
+    private MediaMetadataQueueManager metadataQueueManager;
+
+    /**
+     * 分页查询媒体文件
+     * 
+     * @param libraryId 媒体库ID（可选，为null时查询所有）
+     * @param page 页码（从0开始）
+     * @param pageSize 每页大小
+     * @return 分页结果
+     */
+    public PageVO<MediaFileDTO> getMediaFiles(Long libraryId, int page, int pageSize) {
+        Pageable pageable = PageRequest.of(page, pageSize);
+        Page<MediaFile> result;
+
+        if (libraryId != null) {
+            // 特定媒体库的媒体文件
+            List<MediaFile> files = mediaFileRepository.findByLibraryId(libraryId);
+            int start = page * pageSize;
+            int end = Math.min((page + 1) * pageSize, files.size());
+            List<MediaFile> pageContent = files.subList(start, Math.min(end, files.size()));
+            
+            return PageVO.<MediaFileDTO>builder()
+                    .content(pageContent.stream().map(this::toDTO).collect(Collectors.toList()))
+                    .totalElements(files.size())
+                    .totalPages((files.size() + pageSize - 1) / pageSize)
+                    .currentPage(page)
+                    .pageSize(pageSize)
+                    .hasNext(end < files.size())
+                    .hasPrevious(page > 0)
+                    .build();
+        } else {
+            // 查询所有媒体文件
+            result = mediaFileRepository.findAll(pageable);
+            return PageVO.<MediaFileDTO>builder()
+                    .content(result.getContent().stream().map(this::toDTO).collect(Collectors.toList()))
+                    .totalElements(result.getTotalElements())
+                    .totalPages(result.getTotalPages())
+                    .currentPage(result.getNumber())
+                    .pageSize(result.getSize())
+                    .hasNext(result.hasNext())
+                    .hasPrevious(result.hasPrevious())
+                    .build();
+        }
+    }
+
+    /**
+     * 获取媒体文件详情
+     * 
+     * @param fileId 文件ID
+     * @return 文件详情DTO
+     */
+    public MediaFileDTO getMediaFileDetail(Long fileId) {
+        return mediaFileRepository.findById(fileId)
+                .map(this::toDTO)
+                .orElse(null);
+    }
+
+    /**
+     * 批量重新获取指定媒体库的元数据
+     * 
+     * @param libraryId 媒体库ID
+     */
+    public void reprocessMetadataForLibrary(Long libraryId) {
+        List<MediaFile> files = mediaFileRepository.findByLibraryId(libraryId);
+        
+        for (MediaFile file : files) {
+            // 重置元数据标志
+            file.setMetadataFetched(false);
+            mediaFileRepository.save(file);
+            
+            // 提交到异步队列重新处理
+            Path filePath = Paths.get(file.getFilePath());
+            mediaMetadataEnricher.enrichMediaFileAsync(file, metadataQueueManager);
+        }
+        
+        log.info("Submitted {} files from library {} for metadata reprocessing", files.size(), libraryId);
+    }
+
+    /**
+     * 删除媒体文件记录
+     * 
+     * @param fileId 文件ID
+     * @param deletePhysicalFile 是否同时删除硬盘上的文件
+     */
+    public void deleteMediaFile(Long fileId, boolean deletePhysicalFile) {
+        mediaFileRepository.findById(fileId).ifPresentOrElse(
+                mediaFile -> {
+                    String filePath = mediaFile.getFilePath();
+                    
+                    // 删除数据库记录
+                    mediaFileRepository.delete(mediaFile);
+                    log.info("Deleted media file record: {}", filePath);
+                    
+                    // 可选：删除硬盘上的文件
+                    if (deletePhysicalFile) {
+                        try {
+                            File file = new File(filePath);
+                            if (file.exists()) {
+                                if (file.delete()) {
+                                    log.info("Deleted physical file: {}", filePath);
+                                } else {
+                                    log.warn("Failed to delete physical file: {}", filePath);
+                                }
+                            }
+                        } catch (Exception e) {
+                            log.error("Error deleting physical file: {}", filePath, e);
+                        }
+                    }
+                },
+                () -> log.warn("Media file not found with id: {}", fileId)
+        );
+    }
+
+    /**
+     * 更新媒体文件信息
+     * 
+     * @param fileId 文件ID
+     * @param request 更新请求DTO
+     */
+    public void updateMediaFile(Long fileId, UpdateMediaFileRequest request) {
+        mediaFileRepository.findById(fileId).ifPresentOrElse(
+                mediaFile -> {
+                    if (request.getEpisodeId() != null) {
+                        mediaFile.setEpisodeId(request.getEpisodeId());
+                    }
+                    if (request.getAnimeId() != null) {
+                        mediaFile.setAnimeId(request.getAnimeId());
+                    }
+                    if (request.getAnimeTitle() != null) {
+                        mediaFile.setAnimeTitle(request.getAnimeTitle());
+                    }
+                    if (request.getEpisodeTitle() != null) {
+                        mediaFile.setEpisodeTitle(request.getEpisodeTitle());
+                    }
+                    mediaFileRepository.save(mediaFile);
+                    log.info("Updated media file: {}", fileId);
+                },
+                () -> log.warn("Media file not found with id: {}", fileId)
+        );
+    }
+
+    /**
+     * Entity to DTO 转换
+     */
+    private MediaFileDTO toDTO(MediaFile entity) {
+        return MediaFileDTO.builder()
+                .id(entity.getId())
+                .libraryId(entity.getLibrary() != null ? entity.getLibrary().getId() : null)
+                .fileName(entity.getFileName())
+                .filePath(entity.getFilePath())
+                .size(entity.getSize())
+                .lastModified(entity.getLastModified())
+                .episodeId(entity.getEpisodeId())
+                .animeId(entity.getAnimeId())
+                .animeTitle(entity.getAnimeTitle())
+                .episodeTitle(entity.getEpisodeTitle())
+                .duration(entity.getDuration())
+                .hash(entity.getHash())
+                .width(entity.getWidth())
+                .height(entity.getHeight())
+                .aspectRatio(entity.getAspectRatio())
+                .colorDepth(entity.getColorDepth())
+                .hdrType(entity.getHdrType())
+                .colorSpace(entity.getColorSpace())
+                .colorPrimaries(entity.getColorPrimaries())
+                .videoBitrate(entity.getVideoBitrate())
+                .fps(entity.getFps())
+                .containerFormat(entity.getContainerFormat())
+                .videoCodec(entity.getVideoCodec())
+                .audioCodec(entity.getAudioCodec())
+                .metadataFetched(entity.getMetadataFetched())
+                .createdAt(entity.getCreatedAt())
+                .updatedAt(entity.getUpdatedAt())
+                .build();
+    }
+}

--- a/api/src/main/java/xyz/ezsky/anilink/service/MediaHashService.java
+++ b/api/src/main/java/xyz/ezsky/anilink/service/MediaHashService.java
@@ -1,0 +1,73 @@
+package xyz.ezsky.anilink.service;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+
+/**
+ * 媒体文件哈希计算服务
+ * 
+ * 使用 MD5 算法计算文件前 16MB 的哈希值，用于文件去重和快速识别。
+ * 
+ * 性能优化：
+ * - 仅读取文件前 16MB，避免大文件完全加载到内存
+ * - 使用缓冲流逐块读取，内存占用恒定
+ * - 计算过程中流式处理，不保存中间数据
+ */
+@Log4j2
+@Service
+public class MediaHashService {
+
+    // 前 16MB 用于哈希计算
+    private static final long HASH_SIZE = 16 * 1024 * 1024;
+    private static final int BUFFER_SIZE = 8192;
+
+    /**
+     * 计算文件前 16MB 的 MD5 哈希值
+     * 
+     * @param filePath 视频文件的路径
+     * @return 32 字符的十六进制 MD5 哈希值；失败时返回 null
+     */
+    public String calculateHash(Path filePath) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("MD5");
+
+            try (FileInputStream fis = new FileInputStream(filePath.toFile())) {
+                byte[] buffer = new byte[BUFFER_SIZE];
+                long bytesRead = 0;
+                int len;
+
+                while ((len = fis.read(buffer)) != -1 && bytesRead < HASH_SIZE) {
+                    // 确保不超过 16MB
+                    int bytesToProcess = (int) Math.min(len, HASH_SIZE - bytesRead);
+                    md.update(buffer, 0, bytesToProcess);
+                    bytesRead += bytesToProcess;
+                }
+
+                byte[] digest = md.digest();
+                return bytesToHex(digest);
+            }
+        } catch (IOException e) {
+            log.error("Error reading file for hash calculation: {}", filePath, e);
+            return null;
+        } catch (Exception e) {
+            log.error("Error calculating hash for file: {}", filePath, e);
+            return null;
+        }
+    }
+
+    /**
+     * 将字节数组转换为十六进制字符串
+     */
+    private String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            sb.append(String.format("%02x", b));
+        }
+        return sb.toString();
+    }
+}

--- a/api/src/main/java/xyz/ezsky/anilink/service/MediaMetadataEnricher.java
+++ b/api/src/main/java/xyz/ezsky/anilink/service/MediaMetadataEnricher.java
@@ -1,0 +1,187 @@
+package xyz.ezsky.anilink.service;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import xyz.ezsky.anilink.model.dto.MediaMetadata;
+import xyz.ezsky.anilink.model.entity.MediaFile;
+import xyz.ezsky.anilink.repository.MediaFileRepository;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+/**
+ * 媒体文件元数据合并服务
+ * 
+ * 负责：
+ * 1. 调用 FFprobe 提取视频技术信息（分辨率、编码等）
+ * 2. 计算文件 MD5 哈希值
+ * 3. 合并所有信息到 MediaFile 实体
+ * 4. 提供钩子方法供外部调用接口获取动漫信息
+ * 
+ * 使用异步队列支持大规模并发处理，避免阻塞主扫描线程。
+ */
+@Log4j2
+@Service
+public class MediaMetadataEnricher {
+
+    @Autowired
+    private MediaProbeService mediaProbeService;
+
+    @Autowired
+    private MediaHashService mediaHashService;
+
+    @Autowired
+    private MediaFileRepository mediaFileRepository;
+
+    /**
+     * 异步提取并补充媒体文件的完整元数据
+     * 
+     * 该方法不阻塞调用者，而是将任务提交到后台队列。
+     * 
+     * @param mediaFile 待补充元数据的 MediaFile 实体（必须已有 filePath）
+     * @param queueManager 异步队列管理器
+     */
+    public void enrichMediaFileAsync(MediaFile mediaFile, MediaMetadataQueueManager queueManager) {
+        Path filePath = Paths.get(mediaFile.getFilePath());
+
+        // 提交到异步队列
+        queueManager.submitMetadataExtraction(mediaFile, filePath, updatedFile -> {
+            try {
+                enrichMediaFileSync(updatedFile);
+                // 在数据库中保存更新
+                mediaFileRepository.save(updatedFile);
+                log.info("Successfully enriched metadata for file: {}", updatedFile.getFilePath());
+            } catch (Exception e) {
+                log.error("Error enriching metadata for file: {}", mediaFile.getFilePath(), e);
+            }
+        });
+    }
+
+    /**
+     * 同步提取和补充媒体文件的完整元数据
+     * 
+     * 用于首次扫描时快速提取元数据，或外部调用需要同步获取结果时使用。
+     * 
+     * @param mediaFile 待补充元数据的 MediaFile 实体（必须已有 filePath）
+     */
+    public void enrichMediaFileSync(MediaFile mediaFile) {
+        Path filePath = Paths.get(mediaFile.getFilePath());
+        long startTime = System.currentTimeMillis();
+
+        try {
+            // 第一步：调用 FFprobe 提取视频技术信息
+            MediaMetadata metadata = mediaProbeService.parseMediaInfo(filePath);
+
+            if (metadata != null && metadata.isSuccess()) {
+                // 将元数据合并到 MediaFile 实体
+                mergeMetadataToMediaFile(mediaFile, metadata);
+            } else {
+                log.warn("Failed to extract metadata using FFprobe for file: {}", filePath);
+            }
+
+            // 第二步：计算文件哈希值
+            String hash = mediaHashService.calculateHash(filePath);
+            if (hash != null) {
+                mediaFile.setHash(hash);
+            } else {
+                log.warn("Failed to calculate hash for file: {}", filePath);
+            }
+
+            // 第三步：标记已获取元数据
+            mediaFile.setMetadataFetched(true);
+
+            // 第四步：预留钩子方法供外部调用
+            enrichExternalMetadata(mediaFile);
+
+            long duration = System.currentTimeMillis() - startTime;
+            log.info("Enriched metadata for file in {} ms: {}", duration, filePath);
+
+        } catch (Exception e) {
+            log.error("Error enriching metadata for file: {}", filePath, e);
+            mediaFile.setMetadataFetched(true); // 标记为已尝试，避免重复处理
+        }
+    }
+
+    /**
+     * 将 MediaMetadata 对象的字段合并到 MediaFile 实体
+     */
+    private void mergeMetadataToMediaFile(MediaFile mediaFile, MediaMetadata metadata) {
+        mediaFile.setDuration(metadata.getDuration());
+        mediaFile.setWidth(metadata.getWidth());
+        mediaFile.setHeight(metadata.getHeight());
+        mediaFile.setAspectRatio(metadata.getAspectRatio());
+        mediaFile.setColorDepth(metadata.getColorDepth());
+        mediaFile.setHdrType(metadata.getHdrType());
+        mediaFile.setColorSpace(metadata.getColorSpace());
+        mediaFile.setColorPrimaries(metadata.getColorPrimaries());
+        mediaFile.setVideoBitrate(metadata.getVideoBitrate());
+        mediaFile.setFps(metadata.getFps());
+        mediaFile.setContainerFormat(metadata.getContainerFormat());
+        mediaFile.setVideoCodec(metadata.getVideoCodec());
+        mediaFile.setAudioCodec(metadata.getAudioCodec());
+    }
+
+    /**
+     * 钩子方法：供外部接口调用以获取动漫信息
+     * 
+     * 该方法在元数据提取完成后调用，允许外部通过 API 查询弹幕库或动漫数据库，
+     * 从而填充 episodeId、animeId、animeTitle、episodeTitle 等字段。
+     * 
+     * 当前实现为空，由用户在需要时调用外部接口并更新这些字段。
+     * 
+     * 使用示例：
+     * <pre>
+     * AnimeInfo animeInfo = externalAnimeService.queryByHash(mediaFile.getHash());
+     * if (animeInfo != null) {
+     *     mediaFile.setEpisodeId(animeInfo.getEpisodeId());
+     *     mediaFile.setAnimeId(animeInfo.getAnimeId());
+     *     mediaFile.setAnimeTitle(animeInfo.getAnimeTitle());
+     *     mediaFile.setEpisodeTitle(animeInfo.getEpisodeTitle());
+     * }
+     * </pre>
+     * 
+     * @param mediaFile 已包含技术元数据的 MediaFile 实体
+     */
+    protected void enrichExternalMetadata(MediaFile mediaFile) {
+        // 该方法可被子类重写以实现自定义逻辑
+        // 或由 Controller 层在需要时调用外部接口
+        
+        // 示例钩子点（当前未实现）：
+        // 1. 根据 mediaFile.getHash() 查询弹幕库 API
+        // 2. 根据文件名或其他信息推断动漫信息
+        // 3. 缓存查询结果以避免重复请求
+        
+        log.debug("Hook point for external metadata enrichment: {}", mediaFile.getFilePath());
+    }
+
+    /**
+     * 提供方法供外部 API 调用，用来更新动漫相关字段
+     * 
+     * 该方法可以被 Controller 或其他服务调用，用来设置从外部接口获取的动漫信息。
+     * 
+     * @param mediaFileId 媒体文件 ID
+     * @param episodeId   弹幕库编号（可能为 null）
+     * @param animeId     动漫编号
+     * @param animeTitle  动漫主标题
+     * @param episodeTitle 剧集子标题
+     */
+    public void updateAnimeMetadata(Long mediaFileId, String episodeId, Long animeId, 
+                                   String animeTitle, String episodeTitle) {
+        try {
+            mediaFileRepository.findById(mediaFileId).ifPresentOrElse(
+                    mediaFile -> {
+                        mediaFile.setEpisodeId(episodeId);
+                        mediaFile.setAnimeId(animeId);
+                        mediaFile.setAnimeTitle(animeTitle);
+                        mediaFile.setEpisodeTitle(episodeTitle);
+                        mediaFileRepository.save(mediaFile);
+                        log.info("Updated anime metadata for media file id: {}", mediaFileId);
+                    },
+                    () -> log.warn("Media file not found with id: {}", mediaFileId)
+            );
+        } catch (Exception e) {
+            log.error("Error updating anime metadata for media file id: {}", mediaFileId, e);
+        }
+    }
+}

--- a/api/src/main/java/xyz/ezsky/anilink/service/MediaMetadataQueueManager.java
+++ b/api/src/main/java/xyz/ezsky/anilink/service/MediaMetadataQueueManager.java
@@ -1,0 +1,176 @@
+package xyz.ezsky.anilink.service;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import xyz.ezsky.anilink.model.entity.MediaFile;
+
+import java.io.Closeable;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.concurrent.*;
+import java.util.function.Consumer;
+
+/**
+ * 媒体元数据异步提取队列管理器
+ * 
+ * 负责管理元数据提取的异步队列，实现：
+ * - 高效的线程池管理（避免过多线程导致内存溢出）
+ * - 队列化处理（FIFO）
+ * - 优先级支持（可选，当前采用 FIFO）
+ * - 优雅的队列关闭
+ * 
+ * 设计原则：
+ * 1. 使用固定大小线程池（不超过可用处理器数）
+ * 2. 阻塞队列，防止内存无限增长
+ * 3. 提交任务时若队列满则调用者阻塞等待
+ */
+@Log4j2
+@Service
+public class MediaMetadataQueueManager implements Closeable {
+
+    private final int threadPoolSize;
+    private final BlockingQueue<Runnable> taskQueue;
+    private final ThreadPoolExecutor executor;
+
+    public MediaMetadataQueueManager() {
+        // 线程数：CPU 核心数，最多不超过 4 个（避免过多线程）
+        this.threadPoolSize = Math.min(Runtime.getRuntime().availableProcessors(), 4);
+        
+        // 任务队列最多 500 个任务，防止队列无限增长导致内存问题
+        this.taskQueue = new LinkedBlockingQueue<>(500);
+
+        // 创建线程池
+        this.executor = new ThreadPoolExecutor(
+                threadPoolSize,              // 核心线程数
+                threadPoolSize,              // 最大线程数
+                60,                          // 线程空闲超时时间
+                TimeUnit.SECONDS,            // 超时单位
+                taskQueue,                   // 任务队列（有界队列）
+                new ThreadFactory() {
+                    private final java.util.concurrent.atomic.AtomicInteger count = 
+                        new java.util.concurrent.atomic.AtomicInteger(0);
+                    
+                    @Override
+                    public Thread newThread(Runnable r) {
+                        Thread t = new Thread(r);
+                        t.setName("MediaMetadataExtractor-" + count.incrementAndGet());
+                        t.setDaemon(false);
+                        return t;
+                    }
+                },
+                new CallerWaitsRejectionPolicy()  // 队列满时，调用者线程阻塞等待
+        );
+
+        log.info("MediaMetadataQueueManager initialized with {} threads, queue capacity: 500", threadPoolSize);
+    }
+
+    /**
+     * 提交元数据提取任务到队列
+     * 
+     * 如果队列满，调用者线程会阻塞等待。这确保不会有无限制的任务堆积。
+     * 
+     * @param mediaFile 待提取元数据的 MediaFile 实体
+     * @param filePath  文件完整路径
+     * @param callback  提取完成后的回调（接收更新后的 MediaFile）
+     * @throws RejectedExecutionException 若线程池已关闭
+     */
+    public void submitMetadataExtraction(MediaFile mediaFile, Path filePath, Consumer<MediaFile> callback) {
+        MetadataExtractionTask task = new MetadataExtractionTask(mediaFile, filePath, callback);
+        try {
+            executor.execute(task);
+            log.debug("Submitted metadata extraction task for file: {}", filePath);
+        } catch (RejectedExecutionException e) {
+            log.error("Failed to submit metadata extraction task (executor shutdown?): {}", filePath, e);
+        }
+    }
+
+    /**
+     * 获取队列中待处理的任务数
+     */
+    public int getQueueSize() {
+        return taskQueue.size();
+    }
+
+    /**
+     * 获取活跃线程数
+     */
+    public int getActiveThreadCount() {
+        return executor.getActiveCount();
+    }
+
+    /**
+     * 获取线程池最大线程数
+     */
+    public int getMaxPoolSize() {
+        return executor.getMaximumPoolSize();
+    }
+
+    /**
+     * 优雅关闭线程池
+     * 
+     * - 不接受新任务
+     * - 等待队列中的任务完成（最多 30 秒）
+     */
+    @Override
+    public void close() {
+        try {
+            log.info("Shutting down MediaMetadataQueueManager...");
+            executor.shutdown();
+            
+            // 等待已提交的任务完成，最多 30 秒
+            if (!executor.awaitTermination(30, TimeUnit.SECONDS)) {
+                log.warn("Executor did not terminate in 30 seconds, forcing shutdown...");
+                executor.shutdownNow();
+            }
+            
+            log.info("MediaMetadataQueueManager shut down successfully");
+        } catch (InterruptedException e) {
+            log.error("Interrupted while waiting for executor shutdown", e);
+            executor.shutdownNow();
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * 内部任务类：封装单个文件的元数据提取任务
+     */
+    static class MetadataExtractionTask implements Runnable {
+        private final MediaFile mediaFile;
+        private final Path filePath;
+        private final Consumer<MediaFile> callback;
+
+        MetadataExtractionTask(MediaFile mediaFile, Path filePath, Consumer<MediaFile> callback) {
+            this.mediaFile = mediaFile;
+            this.filePath = filePath;
+            this.callback = callback;
+        }
+
+        @Override
+        public void run() {
+            // 实际提取逻辑由调用者（MediaMetadataEnricher）负责实现
+            // 此处仅定义任务结构
+            if (callback != null) {
+                callback.accept(mediaFile);
+            }
+        }
+    }
+
+    /**
+     * 自定义拒绝策略：队列满时让调用者线程等待
+     * 
+     * 这种策略可以有效防止任务无限堆积，使得调用者在队列满时阻塞。
+     */
+    static class CallerWaitsRejectionPolicy implements RejectedExecutionHandler {
+        @Override
+        public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+            try {
+                // 直接添加到队列，如果队列满则阻塞等待
+                executor.getQueue().put(r);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RejectedExecutionException("Interrupted while waiting to put task in queue", e);
+            }
+        }
+    }
+}
+

--- a/api/src/main/java/xyz/ezsky/anilink/service/MediaProbeService.java
+++ b/api/src/main/java/xyz/ezsky/anilink/service/MediaProbeService.java
@@ -1,0 +1,341 @@
+package xyz.ezsky.anilink.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Service;
+import xyz.ezsky.anilink.model.dto.MediaMetadata;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * FFprobe 媒体文件分析服务
+ *
+ * 使用 FFprobe 提取视频文件的详细元数据信息，包括：
+ * - 分辨率、帧率、比特率等视频流信息
+ * - 色彩空间、HDR 类型等色彩信息
+ * - 编码格式、容器类型等技术规格
+ *
+ * 性能优化：
+ * - 使用流式读取避免大块 JSON 加载到内存
+ * - 并发调用使用共享的 ObjectMapper
+ * - 错误处理基于超时和进程退出状态
+ */
+@Log4j2
+@Service
+public class MediaProbeService {
+
+    private static final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * 解析视频文件的完整元数据
+     *
+     * @param filePath 视频文件的绝对路径
+     * @return MediaMetadata 对象，包含所有提取的信息或错误信息
+     */
+    public MediaMetadata parseMediaInfo(Path filePath) {
+        try {
+            JsonNode ffprobeOutput = executeFFprobe(filePath.toAbsolutePath().toString());
+            if (ffprobeOutput == null) {
+                return MediaMetadata.builder()
+                        .success(false)
+                        .errorMessage("FFprobe output is null")
+                        .build();
+            }
+
+            MediaMetadata metadata = MediaMetadata.builder().build();
+
+            // 解析容器/格式信息
+            parseFormatInfo(ffprobeOutput, metadata);
+
+            // 解析视频流信息
+            parseVideoStreamInfo(ffprobeOutput, metadata);
+
+            // 解析音频流信息
+            parseAudioStreamInfo(ffprobeOutput, metadata);
+
+            metadata.setSuccess(true);
+            return metadata;
+        } catch (Exception e) {
+            log.error("Error parsing media info for file: {}", filePath, e);
+            return MediaMetadata.builder()
+                    .success(false)
+                    .errorMessage(e.getMessage())
+                    .build();
+        }
+    }
+
+    /**
+     * 执行 FFprobe 命令并解析 JSON 输出
+     *
+     * @param filePath 视频文件路径
+     * @return FFprobe JSON 输出的解析结果
+     * @throws IOException    IO 错误或进程异常
+     * @throws InterruptedException 进程被中断
+     */
+    private JsonNode executeFFprobe(String filePath) throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder(
+                "ffprobe",
+                "-v", "quiet",                      // 抑制日志输出
+                "-print_format", "json",             // JSON 格式输出
+                "-show_format",                      // 显示容器/格式信息
+                "-show_streams",                     // 显示视频/音频流信息
+                "-timeout", "30000000",              // 30秒超时（单位：微秒）
+                filePath
+        );
+
+        pb.redirectErrorStream(true);
+
+        Process process = pb.start();
+
+        // 使用 StringBuilder 收集输出（可优化为流式处理）
+        StringBuilder output = new StringBuilder();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()))) {
+            String line;
+            while ((line = reader.readLine()) != null) {
+                output.append(line).append("\n");
+            }
+        }
+
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            log.warn("FFprobe exited with code {} for file: {}", exitCode, filePath);
+            return null;
+        }
+
+        if (output.length() == 0) {
+            log.warn("FFprobe returned empty output for file: {}", filePath);
+            return null;
+        }
+
+        return objectMapper.readTree(output.toString());
+    }
+
+    /**
+     * 解析容器/格式信息（时长、比特率等）
+     */
+    private void parseFormatInfo(JsonNode root, MediaMetadata metadata) {
+        JsonNode formatNode = root.get("format");
+        if (formatNode == null) {
+            return;
+        }
+
+        // 时长（秒 -> 毫秒）
+        JsonNode durationNode = formatNode.get("duration");
+        if (durationNode != null && !durationNode.isNull()) {
+            try {
+                long durationMs = (long) (durationNode.asDouble() * 1000);
+                metadata.setDuration(durationMs);
+            } catch (Exception e) {
+                log.debug("Failed to parse duration", e);
+            }
+        }
+
+        // 容器格式
+        JsonNode formatNameNode = formatNode.get("format_name");
+        if (formatNameNode != null && !formatNameNode.isNull()) {
+            metadata.setContainerFormat(formatNameNode.asText());
+        }
+    }
+
+    /**
+     * 解析第一个视频流的信息
+     * 
+     * 提取：分辨率、帧率、编码、比特率、色彩空间、HDR 等信息
+     */
+    private void parseVideoStreamInfo(JsonNode root, MediaMetadata metadata) {
+        JsonNode streamsNode = root.get("streams");
+        if (streamsNode == null || !streamsNode.isArray()) {
+            return;
+        }
+
+        // 找第一个视频流
+        for (JsonNode stream : streamsNode) {
+            String codecType = stream.get("codec_type").asText("");
+            if (!codecType.equals("video")) {
+                continue;
+            }
+
+            // 宽度、高度
+            JsonNode widthNode = stream.get("width");
+            JsonNode heightNode = stream.get("height");
+            if (widthNode != null && !widthNode.isNull()) {
+                metadata.setWidth(widthNode.asInt());
+            }
+            if (heightNode != null && !heightNode.isNull()) {
+                metadata.setHeight(heightNode.asInt());
+            }
+
+            // 计算宽高比
+            if (metadata.getWidth() != null && metadata.getHeight() != null) {
+                String aspectRatio = calculateAspectRatio(metadata.getWidth(), metadata.getHeight());
+                metadata.setAspectRatio(aspectRatio);
+            }
+
+            // 帧率 (r_frame_rate 格式通常为 "24/1" 或 "30000/1001")
+            parseFrameRate(stream, metadata);
+
+            // 视频编码
+            JsonNode codecNameNode = stream.get("codec_name");
+            if (codecNameNode != null && !codecNameNode.isNull()) {
+                metadata.setVideoCodec(codecNameNode.asText());
+            }
+
+            // 比特率
+            JsonNode bitrateNode = stream.get("bit_rate");
+            if (bitrateNode != null && !bitrateNode.isNull()) {
+                try {
+                    metadata.setVideoBitrate(bitrateNode.asLong());
+                } catch (Exception e) {
+                    log.debug("Failed to parse video bitrate", e);
+                }
+            }
+
+            // 色彩空间
+            JsonNode colorSpaceNode = stream.get("color_space");
+            if (colorSpaceNode != null && !colorSpaceNode.isNull()) {
+                metadata.setColorSpace(colorSpaceNode.asText());
+            }
+
+            // 色彩原色 (color primaries)
+            JsonNode colorPrimariesNode = stream.get("color_primaries");
+            if (colorPrimariesNode != null && !colorPrimariesNode.isNull()) {
+                metadata.setColorPrimaries(colorPrimariesNode.asText());
+            }
+
+            // 色彩深度 (bits_per_raw_sample)
+            JsonNode bitsPerSampleNode = stream.get("bits_per_raw_sample");
+            if (bitsPerSampleNode != null && !bitsPerSampleNode.isNull()) {
+                metadata.setColorDepth(bitsPerSampleNode.asInt() + "-bit");
+            }
+
+            // HDR 信息（通过 side_data_list）
+            parseHDRInfo(stream, metadata);
+
+            // 找到视频流后就返回（仅处理第一个视频流）
+            return;
+        }
+    }
+
+    /**
+     * 解析第一个音频流的编码格式
+     */
+    private void parseAudioStreamInfo(JsonNode root, MediaMetadata metadata) {
+        JsonNode streamsNode = root.get("streams");
+        if (streamsNode == null || !streamsNode.isArray()) {
+            return;
+        }
+
+        // 找第一个音频流
+        for (JsonNode stream : streamsNode) {
+            String codecType = stream.get("codec_type").asText("");
+            if (!codecType.equals("audio")) {
+                continue;
+            }
+
+            JsonNode codecNameNode = stream.get("codec_name");
+            if (codecNameNode != null && !codecNameNode.isNull()) {
+                metadata.setAudioCodec(codecNameNode.asText());
+            }
+
+            // 找到音频流后就返回
+            return;
+        }
+    }
+
+    /**
+     * 解析帧率（处理分数格式 "24/1" 或 "30000/1001"）
+     */
+    private void parseFrameRate(JsonNode stream, MediaMetadata metadata) {
+        JsonNode rFrameRateNode = stream.get("r_frame_rate");
+        if (rFrameRateNode == null || rFrameRateNode.isNull()) {
+            // 如果没有 r_frame_rate，尝试 avg_frame_rate
+            rFrameRateNode = stream.get("avg_frame_rate");
+        }
+
+        if (rFrameRateNode != null && !rFrameRateNode.isNull()) {
+            String frameRateStr = rFrameRateNode.asText();
+            try {
+                // 处理分数格式
+                if (frameRateStr.contains("/")) {
+                    String[] parts = frameRateStr.split("/");
+                    if (parts.length == 2) {
+                        double numerator = Double.parseDouble(parts[0]);
+                        double denominator = Double.parseDouble(parts[1]);
+                        metadata.setFps(numerator / denominator);
+                        return;
+                    }
+                }
+                // 如果不是分数格式，直接解析
+                metadata.setFps(Double.parseDouble(frameRateStr));
+            } catch (Exception e) {
+                log.debug("Failed to parse frame rate: {}", frameRateStr, e);
+            }
+        }
+    }
+
+    /**
+     * 解析 HDR 信息（从 side_data_list 中查找）
+     */
+    private void parseHDRInfo(JsonNode stream, MediaMetadata metadata) {
+        JsonNode sideDataList = stream.get("side_data_list");
+        if (sideDataList == null || !sideDataList.isArray()) {
+            return;
+        }
+
+        for (JsonNode sideData : sideDataList) {
+            String sideDataType = sideData.get("side_data_type").asText("");
+
+            if (sideDataType.contains("Mastering display")) {
+                // 可能是 HDR10
+                metadata.setHdrType("HDR10");
+            } else if (sideDataType.contains("Content light level")) {
+                // Content light level info，配合 Mastering display 表示 HDR10
+                if (metadata.getHdrType() == null) {
+                    metadata.setHdrType("HDR10");
+                }
+            } else if (sideDataType.contains("HDR10 Plus")) {
+                metadata.setHdrType("HDR10+");
+            } else if (sideDataType.contains("Dolby Vision")) {
+                metadata.setHdrType("Dolby Vision");
+            } else if (sideDataType.contains("HLG")) {
+                metadata.setHdrType("HLG");
+            }
+        }
+    }
+
+    /**
+     * 计算宽高比（简化版，返回如 "16:9" 或 "21:9" 的格式）
+     */
+    private String calculateAspectRatio(int width, int height) {
+        if (width == 0 || height == 0) {
+            return null;
+        }
+
+        // 使用最大公约数简化比例
+        int gcd = gcd(width, height);
+        int simplifiedWidth = width / gcd;
+        int simplifiedHeight = height / gcd;
+
+        // 限制宽高比的分子和分母不超过 100
+        if (simplifiedWidth > 100 || simplifiedHeight > 100) {
+            // 如果约分后还很大，直接计算小数宽高比
+            double ratio = (double) width / height;
+            return String.format("%.2f:1", ratio);
+        }
+
+        return simplifiedWidth + ":" + simplifiedHeight;
+    }
+
+    /**
+     * 计算最大公约数（GCD）
+     */
+    private int gcd(int a, int b) {
+        return b == 0 ? a : gcd(b, a % b);
+    }
+}

--- a/api/src/main/java/xyz/ezsky/anilink/service/MediaScannerService.java
+++ b/api/src/main/java/xyz/ezsky/anilink/service/MediaScannerService.java
@@ -45,6 +45,12 @@ public class MediaScannerService {
     @Autowired
     private MediaFileRepository mediaFileRepository;
 
+    @Autowired
+    private MediaMetadataEnricher mediaMetadataEnricher;
+
+    @Autowired
+    private MediaMetadataQueueManager metadataQueueManager;
+
     private final ExecutorService executorService = Executors.newFixedThreadPool(4);
     private final ScheduledExecutorService scheduledExecutor = Executors.newSingleThreadScheduledExecutor();
     private final Map<Path, ScheduledFuture<?>> scheduledTasks = new ConcurrentHashMap<>();
@@ -126,6 +132,9 @@ public class MediaScannerService {
 
     /**
      * 处理单个文件：如果已存在则比较并更新元数据，否则新增记录。
+     * 
+     * 基础信息（文件路径、大小、修改时间）直接保存。
+     * 完整的技术元数据（分辨率、编码等）通过异步队列在后台处理。
      *
      * @param library          所属的媒体库实体
      * @param file             要处理的文件路径
@@ -140,8 +149,13 @@ public class MediaScannerService {
             if (existingFile.getLastModified() != attrs.lastModifiedTime().toMillis() || existingFile.getSize() != attrs.size()) {
                 existingFile.setLastModified(attrs.lastModifiedTime().toMillis());
                 existingFile.setSize(attrs.size());
+                // 重置元数据提取标志，以便重新提取
+                existingFile.setMetadataFetched(false);
                 mediaFileRepository.save(existingFile);
                 log.info("Updated file: {}", filePath);
+                
+                // 提交异步元数据提取任务
+                mediaMetadataEnricher.enrichMediaFileAsync(existingFile, metadataQueueManager);
             }
         } else {
             MediaFile newMediaFile = new MediaFile();
@@ -150,8 +164,12 @@ public class MediaScannerService {
             newMediaFile.setFileName(file.getFileName().toString());
             newMediaFile.setLastModified(attrs.lastModifiedTime().toMillis());
             newMediaFile.setSize(attrs.size());
+            newMediaFile.setMetadataFetched(false);  // 标记待提取元数据
             mediaFileRepository.save(newMediaFile);
             log.info("Added new file: {}", filePath);
+            
+            // 提交异步元数据提取任务
+            mediaMetadataEnricher.enrichMediaFileAsync(newMediaFile, metadataQueueManager);
         }
     }
 
@@ -226,6 +244,8 @@ public class MediaScannerService {
     /**
      * 对文件变更进行延迟处理：如果在延迟期间出现新的变更事件，会取消之前的计划并重新计时，
      * 以实现去抖（debounce）效果，避免重复处理短时间内的多个文件事件。
+     * 
+     * 延迟处理完成后，提交异步元数据提取任务。
      *
      * @param library 所属媒体库
      * @param file    要处理的文件路径

--- a/api/src/main/resources/db/changelog/common/db.changelog-media-metadata.yaml
+++ b/api/src/main/resources/db/changelog/common/db.changelog-media-metadata.yaml
@@ -1,0 +1,142 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-metadata-columns-to-media-file
+      author: anilink
+      description: "Add metadata columns for media file analysis (FFprobe and MD5 hash)"
+      changes:
+        - addColumn:
+            tableName: media_file
+            columns:
+              # 外部接口获取的字段
+              - column:
+                  name: episode_id
+                  type: varchar(255)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: anime_id
+                  type: bigint
+                  constraints:
+                    nullable: true
+              - column:
+                  name: anime_title
+                  type: varchar(500)
+                  constraints:
+                    nullable: true
+              - column:
+                  name: episode_title
+                  type: varchar(500)
+                  constraints:
+                    nullable: true
+              
+              # FFprobe 提取的基础字段
+              - column:
+                  name: duration
+                  type: bigint
+                  constraints:
+                    nullable: true
+                  remarks: "视频时长，单位毫秒"
+              - column:
+                  name: hash
+                  type: varchar(32)
+                  constraints:
+                    nullable: true
+                  remarks: "文件前16MB的MD5哈希值"
+              
+              # 视频分辨率和宽高比
+              - column:
+                  name: width
+                  type: int
+                  constraints:
+                    nullable: true
+                  remarks: "视频宽度（像素）"
+              - column:
+                  name: height
+                  type: int
+                  constraints:
+                    nullable: true
+                  remarks: "视频高度（像素）"
+              - column:
+                  name: aspect_ratio
+                  type: varchar(20)
+                  constraints:
+                    nullable: true
+                  remarks: "宽高比（如 16:9, 21:9）"
+              
+              # 色彩信息
+              - column:
+                  name: color_depth
+                  type: varchar(50)
+                  constraints:
+                    nullable: true
+                  remarks: "色彩深度（8-bit, 10-bit 等）"
+              - column:
+                  name: hdr_type
+                  type: varchar(50)
+                  constraints:
+                    nullable: true
+                  remarks: "HDR类型（HDR10, HDR10+, Dolby Vision, HLG）"
+              - column:
+                  name: color_space
+                  type: varchar(50)
+                  constraints:
+                    nullable: true
+                  remarks: "色彩空间（Rec.709, Rec.2020 等）"
+              - column:
+                  name: color_primaries
+                  type: varchar(50)
+                  constraints:
+                    nullable: true
+                  remarks: "色彩原色（PQ, HLG 等）"
+              
+              # 编码和帧率信息
+              - column:
+                  name: fps
+                  type: float
+                  constraints:
+                    nullable: true
+                  remarks: "帧率（如 23.976, 24, 25, 29.97 等）"
+              - column:
+                  name: video_bitrate
+                  type: bigint
+                  constraints:
+                    nullable: true
+                  remarks: "视频比特率（比特/秒）"
+              - column:
+                  name: video_codec
+                  type: varchar(100)
+                  constraints:
+                    nullable: true
+                  remarks: "视频编码格式（h264, hevc, av1 等）"
+              - column:
+                  name: audio_codec
+                  type: varchar(100)
+                  constraints:
+                    nullable: true
+                  remarks: "音频编码格式（aac, flac, opus 等）"
+              
+              # 容器格式
+              - column:
+                  name: container_format
+                  type: varchar(50)
+                  constraints:
+                    nullable: true
+                  remarks: "容器格式（MKV, MP4, AVI 等）"
+              
+              # 元数据提取标志
+              - column:
+                  name: metadata_fetched
+                  type: boolean
+                  constraints:
+                    nullable: false
+                  defaultValue: false
+                  remarks: "是否已获取完整元数据"
+  
+  - changeSet:
+      id: alter-updated-at-auto
+      author: anilink
+      changes:
+        - modifyDataType:
+            tableName: media_file
+            columnName: updated_at
+            newDataType: TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP

--- a/api/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/api/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -12,6 +12,9 @@ databaseChangeLog:
       file: common/db.changelog-site-config-init.yaml
       relativeToChangelogFile: true
   - include:
+      file: common/db.changelog-media-metadata.yaml
+      relativeToChangelogFile: true
+  - include:
       file: h2/db.changelog-h2-init.yaml
       relativeToChangelogFile: true
   - include:

--- a/ui/src/views/Admin.vue
+++ b/ui/src/views/Admin.vue
@@ -12,11 +12,13 @@ const selectedItem = ref('system')
 const SystemInfo = defineAsyncComponent(() => import('./admin/SystemInfo.vue'))
 const SiteConfig = defineAsyncComponent(() => import('./admin/SiteConfig.vue'))
 const MediaLibrary = defineAsyncComponent(() => import('./admin/MediaLibrary.vue'))
+const VideoFileManager = defineAsyncComponent(() => import('./admin/VideoFileManager.vue'))
 
 const menuItems = [
   { id: 'system', title: '系统信息', icon: 'mdi-information', component: SystemInfo },
   { id: 'site', title: '站点配置', icon: 'mdi-web', component: SiteConfig },
-  { id: 'media', title: '媒体库配置', icon: 'mdi-folder-multiple', component: MediaLibrary }
+  { id: 'media', title: '媒体库配置', icon: 'mdi-folder-multiple', component: MediaLibrary },
+  { id: 'files', title: '视频文件管理', icon: 'mdi-file-video', component: VideoFileManager }
 ]
 
 const userInfo = ref(null)

--- a/ui/src/views/admin/VideoFileManager.vue
+++ b/ui/src/views/admin/VideoFileManager.vue
@@ -1,0 +1,580 @@
+<script setup>
+import { ref, onMounted, computed } from 'vue'
+import axios from 'axios'
+
+const API_BASE = '/api'
+
+const mediaFiles = ref([])
+const loading = ref(false)
+const detailDialog = ref(false)
+const editDialog = ref(false)
+const errorMessage = ref('')
+const successMessage = ref('')
+const selectedLibraryId = ref(null)
+const mediaLibraries = ref([])
+// pagination
+const page = ref(1)
+const pageSize = ref(20)
+const totalElements = ref(0)
+const queueStatus = ref(null)
+const reprocessingLibraryId = ref(null)
+
+// computed total pages
+const pageCount = computed(() => {
+  return Math.ceil(totalElements.value / pageSize.value) || 1
+})
+
+const selectedFile = ref(null)
+const editingFile = ref({
+  episodeId: '',
+  animeId: null,
+  animeTitle: '',
+  episodeTitle: ''
+})
+
+const headers = [
+  { title: '文件名', key: 'fileName', width: '30%' },
+  { title: '大小', key: 'size', width: '10%' },
+  { title: '状态', key: 'metadataFetched', width: '10%' },
+  { title: '视频编码', key: 'videoCodec', width: '12%' },
+  { title: '分辨率', key: 'resolution', width: '12%' },
+  { title: '操作', key: 'actions', width: '26%', sortable: false }
+]
+
+// 获取媒体库列表
+const fetchLibraries = async () => {
+  try {
+    const res = await axios.get(`${API_BASE}/media-library`)
+    if (res.data?.code === 200) {
+      mediaLibraries.value = res.data.data || []
+    }
+  } catch (error) {
+    console.error('获取媒体库失败:', error)
+  }
+}
+
+// 获取媒体文件列表
+const fetchMediaFiles = async () => {
+  loading.value = true
+  try {
+    const params = {
+      page: page.value - 1,
+      pageSize: pageSize.value
+    }
+    if (selectedLibraryId.value) {
+      params.libraryId = selectedLibraryId.value
+    }
+
+    const res = await axios.get(`${API_BASE}/media-files`, { params })
+    if (res.data?.code === 200 && res.data?.data) {
+      const data = res.data.data
+      mediaFiles.value = data.content || []
+      totalElements.value = data.totalElements
+      // synchronize page (server returns zero-based)
+      page.value = data.currentPage + 1
+    }
+  } catch (error) {
+    console.error('获取媒体文件失败:', error)
+    errorMessage.value = '获取文件列表失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+// 获取队列状态
+const fetchQueueStatus = async () => {
+  try {
+    const res = await axios.get(`${API_BASE}/media-files/queue/status`)
+    if (res.data?.code === 200) {
+      queueStatus.value = res.data.data
+    }
+  } catch (error) {
+    console.error('获取队列状态失败:', error)
+  }
+}
+
+// 查看文件详情
+const viewFileDetail = (file) => {
+  selectedFile.value = { ...file }
+  detailDialog.value = true
+}
+
+// 编辑文件信息
+const editFile = (file) => {
+  selectedFile.value = file
+  editingFile.value = {
+    episodeId: file.episodeId || '',
+    animeId: file.animeId || null,
+    animeTitle: file.animeTitle || '',
+    episodeTitle: file.episodeTitle || ''
+  }
+  editDialog.value = true
+}
+
+// 保存编辑
+const saveEdit = async () => {
+  if (!selectedFile.value?.id) return
+
+  loading.value = true
+  try {
+    const res = await axios.put(`${API_BASE}/media-files/${selectedFile.value.id}`, editingFile.value)
+    if (res.data?.code === 200) {
+      successMessage.value = '更新成功'
+      editDialog.value = false
+      await fetchMediaFiles()
+      setTimeout(() => { successMessage.value = '' }, 3000)
+    }
+  } catch (error) {
+    errorMessage.value = '更新失败: ' + (error.response?.data?.msg || error.message)
+  } finally {
+    loading.value = false
+  }
+}
+
+// 删除文件
+const deleteFile = async (fileId, deletePhysicalFile = false) => {
+  if (!confirm(`确定要删除此文件${deletePhysicalFile ? '及其物理文件' : ''}吗？`)) {
+    return
+  }
+
+  loading.value = true
+  try {
+    const res = await axios.delete(`${API_BASE}/media-files/${fileId}`, {
+      params: { deleteFile: deletePhysicalFile }
+    })
+    if (res.data?.code === 200) {
+      successMessage.value = '删除成功'
+      await fetchMediaFiles()
+      setTimeout(() => { successMessage.value = '' }, 3000)
+    }
+  } catch (error) {
+    errorMessage.value = '删除失败: ' + (error.response?.data?.msg || error.message)
+  } finally {
+    loading.value = false
+  }
+}
+
+// 批量重新获取元数据
+const reprocessMetadata = async (libraryId) => {
+  if (!libraryId) {
+    errorMessage.value = '请先选择媒体库'
+    return
+  }
+
+  if (!confirm('确定要重新获取此媒体库中所有文件的元数据吗？')) {
+    return
+  }
+
+  reprocessingLibraryId.value = libraryId
+  try {
+    const res = await axios.post(`${API_BASE}/media-files/reprocess-metadata/${libraryId}`)
+    if (res.data?.code === 200) {
+      successMessage.value = '已提交重新获取任务'
+      // 5秒后刷新队列状态
+      setTimeout(() => {
+        fetchQueueStatus()
+      }, 5000)
+    }
+  } catch (error) {
+    errorMessage.value = '提交任务失败: ' + (error.response?.data?.msg || error.message)
+  } finally {
+    reprocessingLibraryId.value = null
+  }
+}
+
+// 格式化文件大小
+const formatFileSize = (bytes) => {
+  if (!bytes) return '-'
+  if (bytes < 1024) return bytes + ' B'
+  if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(2) + ' KB'
+  if (bytes < 1024 * 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(2) + ' MB'
+  return (bytes / (1024 * 1024 * 1024)).toFixed(2) + ' GB'
+}
+
+// 格式化时长
+const formatDuration = (ms) => {
+  if (!ms) return '-'
+  const seconds = Math.floor(ms / 1000)
+  const hours = Math.floor(seconds / 3600)
+  const minutes = Math.floor((seconds % 3600) / 60)
+  const secs = seconds % 60
+  if (hours > 0) {
+    return `${hours}h ${minutes}m ${secs}s`
+  }
+  return `${minutes}m ${secs}s`
+}
+
+// 获取分辨率
+const getResolution = (file) => {
+  if (file.width && file.height) {
+    return `${file.width}x${file.height}`
+  }
+  return '-'
+}
+
+// 分页变化
+const handlePageChange = (newPage) => {
+  page.value = newPage
+  fetchMediaFiles()
+}
+
+const handlePageSizeChange = (size) => {
+  pageSize.value = size
+  page.value = 1
+  fetchMediaFiles()
+}
+
+// 库选择变化
+const handleLibraryChange = () => {
+  page.value = 1
+  fetchMediaFiles()
+}
+
+// 定时刷新队列状态
+const startQueueStatusPolling = () => {
+  fetchQueueStatus()
+  setInterval(() => {
+    fetchQueueStatus()
+  }, 3000)
+}
+
+onMounted(() => {
+  fetchLibraries()
+  fetchMediaFiles()
+  startQueueStatusPolling()
+})
+</script>
+
+<template>
+  <div>
+    <!-- 警告和成功提示 -->
+    <v-alert v-if="errorMessage" type="error" class="mb-4" closable @update:model-value="v => { if (!v) errorMessage = '' }">
+      {{ errorMessage }}
+    </v-alert>
+    <v-alert v-if="successMessage" type="success" class="mb-4" closable @update:model-value="v => { if (!v) successMessage = '' }">
+      {{ successMessage }}
+    </v-alert>
+
+    <!-- 操作工具栏 -->
+    <v-card class="mb-4">
+      <v-card-text class="pa-4">
+        <div class="d-flex gap-2 align-center flex-wrap">
+          <v-select
+            v-model="selectedLibraryId"
+            :items="mediaLibraries"
+            item-title="name"
+            item-value="id"
+            label="选择媒体库"
+            variant="outlined"
+            density="compact"
+            style="max-width: 300px"
+            @update:model-value="handleLibraryChange"
+            clearable
+          />
+          <v-btn
+            v-if="selectedLibraryId"
+            color="warning"
+            variant="elevated"
+            size="small"
+            :loading="reprocessingLibraryId === selectedLibraryId"
+            @click="reprocessMetadata(selectedLibraryId)"
+          >
+            <v-icon start>mdi-refresh</v-icon>
+            重新获取元数据
+          </v-btn>
+          <v-spacer />
+
+          <!-- 队列状态 -->
+          <v-chip
+            v-if="queueStatus"
+            prepend-icon="mdi-queue"
+            variant="outlined"
+            color="info"
+          >
+            待处理: {{ queueStatus.pendingTasks }} | 活跃: {{ queueStatus.activeThreads }}/{{ queueStatus.maxPoolSize }}
+          </v-chip>
+        </div>
+      </v-card-text>
+    </v-card>
+
+    <!-- 文件列表 -->
+    <v-card>
+      <v-data-table
+        v-model:page="page"
+        :headers="headers"
+        :items="mediaFiles"
+        :loading="loading"
+        :items-per-page="pageSize"
+        density="compact"
+        class="elevation-0"
+      >
+  
+        <template v-slot:item.size="{ item }">
+          <span class="text-caption">{{ formatFileSize(item.size) }}</span>
+        </template>
+
+        <template v-slot:item.metadataFetched="{ item }">
+          <v-chip
+            :color="item.metadataFetched ? 'success' : 'warning'"
+            size="small"
+            label
+          >
+            {{ item.metadataFetched ? '已解析' : '待解析' }}
+          </v-chip>
+        </template>
+
+        <template v-slot:item.videoCodec="{ item }">
+          <span class="text-caption">{{ item.videoCodec || '-' }}</span>
+        </template>
+
+        <template v-slot:item.resolution="{ item }">
+          <span class="text-caption">{{ getResolution(item) }}</span>
+        </template>
+
+        <template v-slot:item.actions="{ item }">
+          <div class="d-flex gap-1">
+            <v-btn
+              icon="mdi-eye"
+              variant="text"
+              size="x-small"
+              color="info"
+              @click="viewFileDetail(item)"
+            />
+            <v-btn
+              icon="mdi-pencil"
+              variant="text"
+              size="x-small"
+              color="primary"
+              @click="editFile(item)"
+            />
+            <v-menu>
+              <template v-slot:activator="{ props }">
+                <v-btn
+                  icon="mdi-delete"
+                  variant="text"
+                  size="x-small"
+                  color="error"
+                  v-bind="props"
+                />
+              </template>
+              <v-list>
+                <v-list-item @click="deleteFile(item.id, false)">
+                  <v-list-item-title>删除记录</v-list-item-title>
+                </v-list-item>
+                <v-list-item @click="deleteFile(item.id, true)">
+                  <v-list-item-title>删除记录及文件</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
+          </div>
+        </template>
+
+        <template v-slot:no-data>
+          <div class="text-center py-8">
+            <v-icon size="64" color="grey-lighten-1">mdi-file-video-outline</v-icon>
+            <p class="text-body-1 mt-4 text-grey">暂无视频文件</p>
+          </div>
+        </template>
+
+        <template v-slot:bottom>
+          <div class="d-flex align-center justify-center gap-4 py-2">
+            <v-select
+              v-model="pageSize"
+              :items="[10, 20, 50, 100]"
+              label="每页数量"
+              variant="outlined"
+              density="compact"
+              style="max-width: 150px"
+              @update:model-value="handlePageSizeChange"
+            />
+            <span class="text-caption text-grey">共 {{ totalElements }} 条记录</span>
+            <v-pagination
+              v-model="page"
+              :length="pageCount"
+            ></v-pagination>
+          </div>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <!-- 文件详情对话框 -->
+    <v-dialog v-model="detailDialog" max-width="900">
+      <v-card v-if="selectedFile">
+        <v-toolbar color="primary" flat>
+          <v-toolbar-title class="text-white">文件详情</v-toolbar-title>
+          <v-spacer />
+          <v-btn icon="mdi-close" color="white" @click="detailDialog = false" />
+        </v-toolbar>
+
+        <v-card-text class="pa-6">
+          <v-row>
+            <v-col cols="12" md="6">
+              <v-list density="compact">
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">文件名</v-list-item-title>
+                  <v-list-item-subtitle>{{ selectedFile.fileName }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">文件路径</v-list-item-title>
+                  <v-list-item-subtitle class="text-caption" style="word-break: break-all;">{{ selectedFile.filePath }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">文件大小</v-list-item-title>
+                  <v-list-item-subtitle>{{ formatFileSize(selectedFile.size) }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">时长</v-list-item-title>
+                  <v-list-item-subtitle>{{ formatDuration(selectedFile.duration) }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">MD5 哈希</v-list-item-title>
+                  <v-list-item-subtitle class="font-monospace text-caption">{{ selectedFile.hash || '-' }}</v-list-item-subtitle>
+                </v-list-item>
+              </v-list>
+            </v-col>
+            <v-col cols="12" md="6">
+              <v-list density="compact">
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">分辨率</v-list-item-title>
+                  <v-list-item-subtitle>{{ getResolution(selectedFile) }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">帧率</v-list-item-title>
+                  <v-list-item-subtitle>{{ selectedFile.fps ? selectedFile.fps.toFixed(2) + ' fps' : '-' }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">视频编码</v-list-item-title>
+                  <v-list-item-subtitle>{{ selectedFile.videoCodec || '-' }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">音频编码</v-list-item-title>
+                  <v-list-item-subtitle>{{ selectedFile.audioCodec || '-' }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">容器格式</v-list-item-title>
+                  <v-list-item-subtitle>{{ selectedFile.containerFormat || '-' }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">HDR 类型</v-list-item-title>
+                  <v-list-item-subtitle>{{ selectedFile.hdrType || '-' }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">色彩空间</v-list-item-title>
+                  <v-list-item-subtitle>{{ selectedFile.colorSpace || '-' }}</v-list-item-subtitle>
+                </v-list-item>
+              </v-list>
+            </v-col>
+          </v-row>
+
+          <v-divider class="my-4" />
+
+          <v-row>
+            <v-col cols="12">
+              <span class="text-subtitle-2 font-weight-medium">动漫信息</span>
+              <v-list density="compact" class="mt-2">
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">番名</v-list-item-title>
+                  <v-list-item-subtitle>{{ selectedFile.animeTitle || '-' }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">话数</v-list-item-title>
+                  <v-list-item-subtitle>{{ selectedFile.episodeTitle || '-' }}</v-list-item-subtitle>
+                </v-list-item>
+                <v-list-item>
+                  <v-list-item-title class="text-caption text-grey">弹幕库ID</v-list-item-title>
+                  <v-list-item-subtitle>{{ selectedFile.episodeId || '-' }}</v-list-item-subtitle>
+                </v-list-item>
+              </v-list>
+            </v-col>
+          </v-row>
+        </v-card-text>
+
+        <v-divider />
+
+        <v-card-actions class="pa-4">
+          <v-spacer />
+          <v-btn color="primary" variant="elevated" @click="editFile(selectedFile)">
+            编辑信息
+          </v-btn>
+          <v-btn color="grey" variant="text" @click="detailDialog = false">
+            关闭
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+
+    <!-- 编辑对话框 -->
+    <v-dialog v-model="editDialog" max-width="600">
+      <v-card v-if="selectedFile">
+        <v-toolbar color="primary" flat>
+          <v-toolbar-title class="text-white">编辑文件信息</v-toolbar-title>
+          <v-spacer />
+          <v-btn icon="mdi-close" color="white" @click="editDialog = false" />
+        </v-toolbar>
+
+        <v-card-text class="pa-6">
+          <v-form>
+            <v-text-field
+              v-model="editingFile.animeTitle"
+              label="番名"
+              variant="outlined"
+              color="primary"
+              class="mb-4"
+            />
+
+            <v-text-field
+              v-model="editingFile.episodeTitle"
+              label="话数 / 标题"
+              variant="outlined"
+              color="primary"
+              class="mb-4"
+            />
+
+            <v-text-field
+              v-model.number="editingFile.animeId"
+              label="番号"
+              type="number"
+              variant="outlined"
+              color="primary"
+              class="mb-4"
+            />
+
+            <v-text-field
+              v-model="editingFile.episodeId"
+              label="弹幕库 ID"
+              variant="outlined"
+              color="primary"
+            />
+          </v-form>
+        </v-card-text>
+
+        <v-divider />
+
+        <v-card-actions class="pa-4">
+          <v-spacer />
+          <v-btn color="grey" variant="text" @click="editDialog = false">
+            取消
+          </v-btn>
+          <v-btn
+            color="primary"
+            variant="elevated"
+            :loading="loading"
+            @click="saveEdit"
+          >
+            保存
+          </v-btn>
+        </v-card-actions>
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<style scoped>
+:deep(.v-data-table) {
+  background: transparent;
+}
+
+.font-monospace {
+  font-family: 'Courier New', monospace;
+}
+</style>


### PR DESCRIPTION
【新增】(后端): 添加MediaMetadataQueueManager和MediaProbeService以支持异步元数据提取

【新增】(数据库): 为media_file表添加元数据字段（时长、分辨率、色彩信息、编码格式等）

【新增】(前端): 开发VideoFileManager UI用于媒体文件管理，包括查看详情、编辑元数据、重新提取