### PR TITLE
更新基础镜像为 eclipse-temurin:17-jdk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-ea
+FROM eclipse-temurin:17-jdk
 
 # 更新包管理器并安装 FFmpeg 和相关工具
 RUN apt-get update && apt-get install -y \
@@ -11,10 +11,10 @@ RUN apt-get update && apt-get install -y \
 RUN mkdir -p /app/config
 
 # 设置环境变量，用于用户指定媒体目录和配置目录
-ENV CONFIG_DIR /app/config
+ENV CONFIG_DIR=/app/config
 ADD api/target/ani-link-service.jar app.jar
 ENV LANG=C.UTF-8
-ENV LANGUAGE C.UTF-8
+ENV LANGUAGE=C.UTF-8
 ENV LC_ALL=C.UTF-8
 EXPOSE 8081
 


### PR DESCRIPTION
【修改】(Dockerfile): 更新基础镜像为 eclipse-temurin:17-jdk，并修正环境变量格式